### PR TITLE
Update psABI to match Itanium C++ ABI fixes for passing class objects

### DIFF
--- a/low-level-sys-info.tex
+++ b/low-level-sys-info.tex
@@ -477,28 +477,17 @@ types works as follows:
   and the first eightbyte is SSE and all other eightbytes are SSEUP, it
   can be passed in a register, otherwise, it will be passed in memory.}.
 
-\item If a C++ object has either a non-trivial copy constructor
-    or a non-trivial destructor
-  \footnote{A de/constructor is trivial if it is an implicitly-declared
-             default de/constructor and if:
-    \begin{itemize}
-        \item its class has no virtual functions
-          and no virtual base classes, and
-
-        \item all the direct base classes of its class have trivial
-          de/constructors, and
-
-        \item for all the nonstatic data members of its class that are
-          of class type (or array thereof), each such class has a
-          trivial de/constructor.
-    \end{itemize}},
+\item If a C++ object is non-trivial for the purpose of calls, as
+    specified in the C++ ABI \footnote{See section~\ref{section-cpp}
+    for details on C++ ABI.},
     it is passed by invisible reference
     (the object is replaced in the parameter list by a pointer that
     has class INTEGER)
-  \footnote{An object with either a non-trivial copy
-   constructor or a non-trivial destructor cannot be passed by value
-   because such objects must have well defined addresses.  Similar
-   issues apply when returning an object from a function.}.
+  \footnote{An object whose type is non-trivial for the purpose of
+   calls cannot be passed by value because such objects must have the
+   same address in the caller and the callee. Similar
+   issues apply when returning an object from a function.
+   See C++17 [class.temporary] paragraph 3.}.
 
 \item If the size of the aggregate exceeds a single \eightbyte, each is
     classified separately.  Each \eightbyte gets initialized to class NO_CLASS.


### PR DESCRIPTION
Update psABI to match Itanium C++ ABI fixes for passing class objects indirectly when they have non-trivial or deleted move constructors, or deleted copy constructors or destructors.

Rendered:

![screenshot from 2017-10-30 17 36 13](https://user-images.githubusercontent.com/232783/32202428-eabe2fe6-bd99-11e7-9f53-f78e3b9eedd7.png)
