### PR TITLE
Document _Alignof(max_align_t)

### DIFF
--- a/abi.tex
+++ b/abi.tex
@@ -26,7 +26,7 @@ Version \version}}
 
 \begin{description}
 
-
+\item[1.01] Document _Alignof(max_align_t).
 \item[1.0] Document _Unwind_GetIPInfo.  Update to match C++ ABI.  Add
   chapter for alternate code sequences For security.
 \item[0.99] Add description of TLS relocations (thanks to Alexandre

--- a/low-level-sys-info.tex
+++ b/low-level-sys-info.tex
@@ -146,6 +146,8 @@ The \code{__int128} type is stored in little-endian order in memory,
 i.e., the 64 low-order bits are stored at a a lower address than the
 64 high-order bits.
 
+The value of \code{_Alignof(max_align_t)} is 16.
+
 A null pointer (for all types) has the value zero.
 
 The type \codeindex{size\_t} is defined as \code{unsigned long} for LP64


### PR DESCRIPTION
This documents the "fundamental alignment" (per [C18 6.2.8.2](https://web.archive.org/web/20181230041359if_/http://www.open-std.org/jtc1/sc22/wg14/www/abq/c17_updated_proposed_fdis.pdf)) of the ABI. Fundamental alignments shall be supported by the implementation for objects of all storage durations.